### PR TITLE
Updated the tests to call natively without Java primatives created.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-/target
-/src/main/java/org/unix
+release/
+target/
+.idea/
+*.iml
+*/*.iml
+.DS_Store
+classes/
+generated/
+a.out
+*.dylib
+*.so
+*.dll
+hs_err_pid*.log
+out/

--- a/Readme.md
+++ b/Readme.md
@@ -2,29 +2,37 @@
 
 Benchmarks for Java JNI vs Project Panama on Linux (Fedora 35) with JDK (openjdk 17-panama 2021-09-14)
 
-## Run benchmarks
+Setup instructions for benchmark:
 
-Clone the project
+## Clone the project
 
 ```bash
 git clone 
 ```
 
-Setup Java 17 panama build using SDK man
+## Setup Java 17 panama build using SDK man
 
 ```bash
 sdk install java 17.ea.3.pma-open
 sdk use java 17.ea.3.pma-open
 ```
 
-Create Java bindings for `unistd.h`
+## Create Java bindings for `unistd.h`
 
+Linux
 ```bash
-jextract --source -t src.main.java.org.unix -I /usr/include /usr/include/unistd.h
+jextract --source -d generated/src/main/java -t org.unix -I /usr/include /usr/include/unistd.h
 ```
 
-Build and run using Maven
+MacOS 
+```
+export C_INCLUDE=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+jextract --source -d generated/src/main/java -t org.unix -I $C_INCLUDE $C_INCLUDE/unistd.h
+```
 
+## Build and run using Maven
+
+When running the benchmark it currently only works for Linux.
 ```bash
 mvn clean verify 
 java -jar target/benchmarks.jar

--- a/jextract_sample.sh
+++ b/jextract_sample.sh
@@ -1,0 +1,3 @@
+# Linux
+jextract --source -d generated/src/main/java -t org.unix -I /usr/include /usr/include/unistd.h
+

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,24 @@ THE POSSIBILITY OF SUCH DAMAGE.
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                           <sources>
+                               <source>generated/src/main/java</source>
+                           </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>

--- a/src/main/java/org/sample/FFIBenchmark.java
+++ b/src/main/java/org/sample/FFIBenchmark.java
@@ -35,32 +35,20 @@ public class FFIBenchmark {
 
     @Benchmark
     public void JNI() {
-        callJNI();
+      org.bytedeco.javacpp.linux.getpid();
     }
 
     @Benchmark
     public void panamaDowncall() throws Throwable {
-        callPanamaDowncall();
+        linker.downcallHandle(
+                lookup.lookup("getpid").get(),
+                MethodType.methodType(int.class),
+                FunctionDescriptor.of(CLinker.C_INT))
+              .invokeExact();
     }
 
     @Benchmark
     public void panamaJExtract() {
-        callPanamaJExtract();
-    }
-
-    public int callJNI() {
-        return org.bytedeco.javacpp.linux.getpid();
-    }
-
-    public long callPanamaDowncall() throws Throwable {
-        var getpid = linker.downcallHandle(
-                lookup.lookup("getpid").get(),
-                MethodType.methodType(int.class),
-                FunctionDescriptor.of(CLinker.C_INT));
-        return ((int) getpid.invokeExact());
-    }
-
-    public long callPanamaJExtract() {
-        return org.unix.unistd_h.getpid();
+       org.unix.unistd_h.getpid();
     }
 }


### PR DESCRIPTION
@deepu105 
I did some minor changes.

**Generated Sources**
I Updated the Readme.md to run jextract to generate source using `-d` switch and added the generate source plugin in the maven pom.xml. 

**Reduce code (call stack)**
By reducing the calls the benchmark can be closer to the native symbol (method handle). Also, we might want to create another branch for JDK 18+ because the API has changed. I can help convert later.

Let me know what you think.
:-)