### PR TITLE
Updated benchmarks to reduce memory and avoid blackholes 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,9 +39,14 @@ java -jar target/benchmarks.jar
 ```
 
 ## Typical Results
+These results vary because they were ran on a developer machine (macbook pro) with other services running. Also, according 
+to the Java Microbenchmark Harness docs, to avoid `blackholes` (methods that return void). e.g. If you call getPid() and return void
+the JVM will optimize by removing dead code. To ensure the code isn't removed the method returns a primitive (int). 
+Below smaller numbers the better.
+
 ```text
 Benchmark                    Mode  Cnt  Score   Error  Units
-FFIBenchmark.JNI             avgt   20  9.103 ± 0.148  ns/op
-FFIBenchmark.panamaDowncall  avgt   20  8.265 ± 0.114  ns/op
-FFIBenchmark.panamaJExtract  avgt   20  8.528 ± 0.112  ns/op
+FFIBenchmark.JNI             avgt   40  9.698 ± 0.532  ns/op
+FFIBenchmark.panamaDowncall  avgt   40  8.431 ± 0.096  ns/op
+FFIBenchmark.panamaJExtract  avgt   40  8.488 ± 0.099  ns/op
 ```


### PR DESCRIPTION
@deepu105  I hope you like the changes, I was playing around with the benchmarks and noticed a few things.

JMH calls blackholes when the jvm optimizes by removing dead code.
Similar to the code below when getting pids we don't return and therefore it may think it should remove the code. @deepu105 's original code benchmark correctly but delegated to another method. 
;-)

```
public void doSomething() {
     distance(p1, p2);
}
```

To trigger or prevent optimization the docs say to do the following:
```
public int doSomething() {
     return distance(p1, p2);
}
```

Since C code returns an int onto the Java side a primitive is created and returned. 
